### PR TITLE
Fall back to iframe if worker via blob is not supported and opScriptURL is not set

### DIFF
--- a/src/operative.js
+++ b/src/operative.js
@@ -468,7 +468,7 @@
 	 */
 	function operative(module, dependencies) {
 
-		var OperativeContext = operative.hasWorkerSupport ?
+		var OperativeContext = operative.hasWorkerSupport && (workerViaBlobSupport || opScriptURL) ?
 			Operative.Worker : Operative.Iframe;
 
 		if (typeof module == 'function') {


### PR DESCRIPTION
Operative completely fails right now if worker via blob is not supported and you don't set the opScriptURL with setSelfURL.
I think it would be a better idea to fall back to iframe in this case.
